### PR TITLE
Add support for x509 certificsates.

### DIFF
--- a/dev_credentials.c
+++ b/dev_credentials.c
@@ -1,0 +1,9 @@
+#ifndef __DEV_CREDENTIALS_H__
+#define __DEV_CREDENTIALS_H__
+
+#if !MBED_CONF_APP_WITH_PSK
+#error "Replace dev_credentials.c with your own developer cert."
+#endif
+
+
+#endif //__DEV_CREDENTIALS_H__

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -48,6 +48,7 @@
     "with_rg_server": true,
     "with_bs_server": false,
     "with_dtls": true,
+    "with_psk": true,
     "psk_identity": "\"***PLEASE SET PSK IDENTITY HERE***\"",
     "psk_key": "\"***PLEASE SET PSK KEY HERE***\"",
     "serial_menu_echo": true


### PR DESCRIPTION
Added the with_psk flag into mbed_app.json. Set this to true to use PSK
or false to use certificates.

Modified device_config_serial_menu to optionally use certificate data
built into the image.